### PR TITLE
Update template to work with latest mos-hardware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ debug = 2
 
 [dependencies]
 # here you better pin the mos-hardware version to use
-mos-hardware = {path = "/Users/mikael/github/mos-hardware"}
-#mos-hardware = {git = "https://github.com/mlund/mos-hardware", branch = "main"}
+mos-hardware = {git = "https://github.com/mlund/mos-hardware", branch = "main"}
 mos-alloc = "0.2"
 ufmt-stdio = "0"
 rand = {version = "0.8.5", default-features = false}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use ufmt_stdio::*;
 
 #[start]
 fn _main(_argc: isize, _argv: *const *const u8) -> isize {
-    let mut rng = sid::SIDRng::default(c64::sid());
+    let mut rng = sid::SIDRng::new(c64::sid());
     for offset in 0..40 * 25 {
         let character = [77u8, 78u8].choose(&mut rng).copied().unwrap();
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 
 #![no_std]
 #![feature(start)]
-#![feature(default_alloc_error_handler)]
 
 use core::panic::PanicInfo;
 use mos_hardware::{c64, sid};


### PR DESCRIPTION
Great template, I had to make three minor changes to make it build cleanly:
- remove unnecessary feature
- update initialization of `SIDRng`
- Point mos-hardware dependency to repo instead of local folder